### PR TITLE
Update SWBuildID and DateCode attributes

### DIFF
--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -88,6 +88,16 @@ env:
                  || '8')
         )
     }}
+  branch_to_build_type: >-
+    ${{ github.ref_name == 'main' 
+        && 'rel'
+        || (startsWith(github.ref_name, 'rc')
+            && 'rc'
+            || ( github.ref_name == 'dev'
+                 && 'dev'
+                 || 'unk')
+        )
+    }}
 
 jobs:
   firmware-build:
@@ -120,6 +130,28 @@ jobs:
           OTA_VERSION="${META_DATE}${{ env.branch_to_ota }}${BUILD_ID_MOD100}"
           echo "OTA version: '${OTA_VERSION}'"
           echo "OTA_VERSION=${OTA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "BUILD_DATE=${META_DATE}" >> "$GITHUB_OUTPUT"
+          echo "BUILD_ID_MOD100=${BUILD_ID_MOD100}" >> "$GITHUB_OUTPUT"
+
+      - name: Update dateCode in ZAP config
+        if: ${{ env.IS_BTL != 'yes' }}
+        run: |
+          cd "${{ env.PROJECT_NAME }}/config/zcl"
+          cp "zcl_config.zap" "zcl_config.zap~"
+          FILTER='(. | .endpointTypes[].clusters[] | select(.name == "Basic") | .attributes[] | select(.code == 6)).defaultValue'
+          DATE_CODE="${{ steps.ota_version.outputs.BUILD_DATE}}.${{ env.branch_to_build_type }}.${{ steps.ota_version.outputs.BUILD_ID_MOD100 }}"
+          echo "Date Code = '${DATE_CODE}'"
+          jq "${FILTER} |= \"${DATE_CODE}\"" "zcl_config.zap~" > "zcl_config.zap"
+
+      - name: Update SWBuildId in ZAP config
+        if: ${{ env.IS_BTL != 'yes' }}
+        run: |
+          cd "${{ env.PROJECT_NAME }}/config/zcl"
+          cp "zcl_config.zap" "zcl_config.zap~"
+          FILTER='(. | .endpointTypes[].clusters[] | select(.name == "Basic") | .attributes[] | select(.code == 16384)).defaultValue'
+          SW_BUILD_ID="SHA1: $(echo ${{ github.sha }} | cut -c1-10)"
+          echo "Date Code = '${SW_BUILD_ID}'"
+          jq "${FILTER} |= \"${SW_BUILD_ID}\"" "zcl_config.zap~" > "zcl_config.zap"
 
       - name: Generate New Project
         if: env.IS_NEW_PROJECT == 'yes'

--- a/TBS2Torch/app.c
+++ b/TBS2Torch/app.c
@@ -145,21 +145,6 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
                                      0,
                                      0,
                                      NULL);
-  // update basic cluster
-  uint8_t dateCode[16];
-  memset(dateCode, 0x00, sizeof(dateCode));
-  snprintf(&dateCode[1],
-           sizeof(dateCode) - 1,
-           "%d",
-           EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_FIRMWARE_VERSION);
-  dateCode[0] = strlen(&dateCode[1]);
-  EmberAfStatus status = emberAfWriteServerAttribute(emberAfPrimaryEndpoint(),
-                                                     ZCL_BASIC_CLUSTER_ID,
-                                                     ZCL_DATE_CODE_ATTRIBUTE_ID,
-                                                     dateCode,
-                                                     ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
-  sl_zigbee_app_debug_println("Updated date code attribute: 0x%02x", status);
-
   handlerRhtUpdate();
 }
 

--- a/TBS2Torch/config/zcl/zcl_config.zap
+++ b/TBS2Torch/config/zcl/zcl_config.zap
@@ -18,15 +18,15 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "..\\..\\..\\..\\..\\SimplicityStudio\\SDKs\\gecko_sdk\\app\\zcl\\zcl-zap.json",
+      "path": "..\\..\\..\\..\\..\\..\\..\\..\\SiliconLabs\\SimplicityStudio\\v5\\developer\\adapter_packs\\zap\\resources\\app.asar\\zcl-builtin\\silabs\\zcl.json",
       "type": "zcl-properties",
       "category": "zigbee",
       "version": 1,
-      "description": "Zigbee Silabs ZCL data"
+      "description": "ZigbeePro test data"
     },
     {
       "pathRelativity": "relativeToZap",
-      "path": "..\\..\\..\\..\\..\\SimplicityStudio\\SDKs\\gecko_sdk\\protocol\\zigbee\\app\\framework\\gen-template\\gen-templates.json",
+      "path": "..\\..\\..\\..\\..\\..\\SimplicityStudio\\SDKs\\gecko_sdk\\protocol\\zigbee\\app\\framework\\gen-template\\gen-templates.json",
       "type": "gen-templates-json",
       "category": "zigbee",
       "version": "zigbee-v0"
@@ -221,7 +221,7 @@
               "storageOption": "RAM",
               "singleton": 1,
               "bounded": 0,
-              "defaultValue": "0xFF",
+              "defaultValue": "0x00",
               "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -237,7 +237,7 @@
               "storageOption": "RAM",
               "singleton": 1,
               "bounded": 0,
-              "defaultValue": "0xFF",
+              "defaultValue": "0x09",
               "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -269,7 +269,7 @@
               "storageOption": "RAM",
               "singleton": 1,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": "https://github.com/Adminiuga/TBS2Torch",
               "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -285,7 +285,7 @@
               "storageOption": "RAM",
               "singleton": 1,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": "uninitialized",
               "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -1139,22 +1139,6 @@
               "bounded": 0,
               "defaultValue": "0x0000",
               "reportable": 0,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "current frequency",
-              "code": 4,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int16u",
-              "included": 0,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0x0000",
-              "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0


### PR DESCRIPTION
Update SWBuildID and DateCode attributes of the basic cluster during project build.

SWBuildID contains the commit SHA1 Hash
DateCode contains `<BuildDate>.<Type>.<Build Number>`

where: `<Type>` is:
- `dev` for `dev' branch
- `rel` for `main` branch
- `rc`  for branches starting with RC -- release candidates branches
- `unk` for any other branch

<Build Number> is Github Action run number mod 100.