### PR TITLE
Add a Battery Monitor

### DIFF
--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -57,6 +57,8 @@ jobs:
       sdkpatchpath: "patches/GeckoSDK"
       metadata_extra: "{}"
       ota_string: ${{ inputs.app_ota_string }}
+      sdk_extensions: |
+        "https://github.com/Adminiuga/Raz1_custom_components_extension"
 
 
   bootloader-build:

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -138,6 +138,10 @@ jobs:
             echo "Clonining ${EXT}"
             git clone "$EXT"
           done
+
+      - name: Trust SDK Extenstions
+        if: ${{ inputs.sdk_extensions != '' }}
+        run: |
           for EXT_PATH in ${{ env.sdk_path }}/extension/*
           do
             echo "Trusting ${EXT_PATH}"

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -141,7 +141,7 @@ jobs:
           for EXT_PATH in ${{ env.sdk_path }}/extension/*
           do
             echo "Trusting ${EXT_PATH}"
-            slc configuration trust -extpath "$EXT_PATH"
+            slc signature trust -extpath "$EXT_PATH"
           done
 
       - name: Generate OTA Version

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -60,6 +60,12 @@ on:
         default: ''
         type: string
 
+      sdk_extensions:
+        required: false
+        description: List of SDK extensions git URLs
+        default: ''
+        type: string
+
     outputs:
       project_name:
         description: Name of the generated SLC project
@@ -98,6 +104,7 @@ env:
                  || 'unk')
         )
     }}
+  sdk_path: /gecko_sdk
 
 jobs:
   firmware-build:
@@ -119,6 +126,23 @@ jobs:
       - name: Adjust permission
         shell: bash
         run: chown -R builder .
+
+      - name: Install SDK Extenstions
+        if: ${{ inputs.sdk_extensions != '' }}
+        shell: bash
+        run: |
+          mkdir -p ${{ env.sdk_path }}/extension || true
+          cd ${{ env.sdk_path }}/extension
+          for EXT in ${{ inputs.sdk_extensions }}
+          do
+            echo "Clonining ${EXT}"
+            git clone "$EXT"
+          done
+          for EXT_PATH in ${{ env.sdk_path }}/extension/*
+          do
+            echo "Trusting ${EXT_PATH}"
+            slc configuration trust -extpath "$EXT_PATH"
+          done
 
       - name: Generate OTA Version
         id: ota_version

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -120,6 +120,23 @@ popd
 
 Once the build is complete, the build artifacts are going to be in `./build/release` folder.
 
+## Using a Li Ion 18650 cell for power
+
+It is possible to use a LiIon 18650 cell for powering. Just find an appropriate battery holder
+and connect:
+
+| Header | Pin Number | Function | Connect to |
+| ---  | -- | ------ | -------- |
+| EXPA |  1 | Ground | Battery "-" |
+| EXPA |  7 | Battery Voltage Sense (PA6) | [Voltage Divider](https://en.wikipedia.org/wiki/Voltage_divider) for battery voltage sensing |
+| EXPB | 18 | 5V     | Battery "+" |
+
+The new version supports battery voltage and % charge remaining, assuming you are using a standard
+18650 cell. Since fully charged battery voltage exceeds 3.3V, you cannot feed it directly to header
+pin #7, but need to use a [volgage divider](https://en.wikipedia.org/wiki/Voltage_divider) to reduce the voltage. The current firmware is using 18K + 27K voltage divider (just because I had
+those resistor handy), if you change those, then you would need to update the resistor values in
+[config/sl_battery_monitor_config.h](./TBS2Torch/config/sl_battery_monitor_config.h) and recompile the firmware.
+
 [Reference Table]: #
 [Torch Light GH]: https://github.com/Adminiuga/TBS2Torch.git "TBS2 Torch Light Github Project"
 

--- a/TBS2Torch/TBS2Torch.pintool
+++ b/TBS2Torch/TBS2Torch.pintool
@@ -1,7 +1,75 @@
 <?xml version="1.0" encoding="ASCII"?>
 <device:XMLDevice xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:device="http://www.silabs.com/ss/hwconfig/document/device.ecore" name="pin_tool.EFR32MG12P332F1024GL125" partId="mcu.arm.efr32.mg12.efr32mg12p332f1024gl125" contextId="com.silabs.sdk.stack.super:4.3.1._-184907989">
   <mode name="DefaultMode">
+    <property object="DBG" propertyId="ABModule.selectedRequirement" value="dbg%T%SL_DEBUG%T%sl_debug_swo_config.h"/>
+    <property object="DBG" propertyId="ABPeripheral.included" value="true"/>
     <property object="DefaultMode" propertyId="mode.diagramLocation" value="100, 100"/>
+    <property object="I2C1" propertyId="ABModule.selectedRequirement" value="i2c%T%SL_I2CSPM_SENSOR%T%sl_i2cspm_sensor_config.h"/>
+    <property object="I2C1" propertyId="ABPeripheral.included" value="true"/>
+    <property object="PB10" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_BOARD_ENABLE_SENSOR_HALL%T%sl_board_control_config.h"/>
+    <property object="PB10" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PC3" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_ICM20648_SPI_CS%T%sl_icm20648_config.h"/>
+    <property object="PC3" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PD14" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_SIMPLE_BUTTON_BTN0%T%sl_simple_button_btn0_config.h"/>
+    <property object="PD14" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PD15" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_SIMPLE_BUTTON_BTN1%T%sl_simple_button_btn1_config.h"/>
+    <property object="PD15" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PD8" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_SIMPLE_LED_LED0%T%sl_simple_led_led0_config.h"/>
+    <property object="PD8" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PF10" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_BOARD_ENABLE_SENSOR_MICROPHONE%T%sl_board_control_config.h"/>
+    <property object="PF10" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PF12" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_ICM20648_INT%T%sl_icm20648_config.h"/>
+    <property object="PF12" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PF14" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_BOARD_ENABLE_SENSOR_GAS%T%sl_board_control_config.h"/>
+    <property object="PF14" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PF8" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_BOARD_ENABLE_SENSOR_IMU%T%sl_board_control_config.h"/>
+    <property object="PF8" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PF9" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_BOARD_ENABLE_SENSOR_PRESSURE%T%sl_board_control_config.h"/>
+    <property object="PF9" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PK1" propertyId="ABModule.selectedRequirement" value="gpio%T%SL_MX25_FLASH_SHUTDOWN_CS%T%sl_mx25_flash_shutdown_usart_config.h"/>
+    <property object="PK1" propertyId="pin.reserve" value="Reserved"/>
+    <property object="PORTIO" propertyId="portio.dbg.enable.swv" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.i2c1.enable.scl" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.i2c1.enable.sda" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.i2c1.location.scl" value="17"/>
+    <property object="PORTIO" propertyId="portio.i2c1.location.sda" value="17"/>
+    <property object="PORTIO" propertyId="portio.prs.enable.ch0" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.prs.location.ch0" value="8"/>
+    <property object="PORTIO" propertyId="portio.pti.enable.dframe" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.pti.enable.dout" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.pti.location.dframe" value="6"/>
+    <property object="PORTIO" propertyId="portio.pti.location.dout" value="6"/>
+    <property object="PORTIO" propertyId="portio.timer0.enable.cc0" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.timer0.enable.cc1" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.timer0.enable.cc2" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.timer0.location.cc0" value="19"/>
+    <property object="PORTIO" propertyId="portio.timer0.location.cc1" value="19"/>
+    <property object="PORTIO" propertyId="portio.timer0.location.cc2" value="19"/>
+    <property object="PORTIO" propertyId="portio.usart0.enable.cts" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart0.enable.rts" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart0.enable.rx" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart0.enable.tx" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart0.location.cts" value="30"/>
+    <property object="PORTIO" propertyId="portio.usart0.location.rts" value="30"/>
+    <property object="PORTIO" propertyId="portio.usart3.enable.clk" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart3.enable.rx" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart3.enable.tx" value="Enabled"/>
+    <property object="PORTIO" propertyId="portio.usart3.location.clk" value="18"/>
+    <property object="PORTIO" propertyId="portio.usart3.location.rx" value="18"/>
+    <property object="PORTIO" propertyId="portio.usart3.location.tx" value="18"/>
+    <property object="PRS.CH0" propertyId="ABModule.selectedRequirement" value="prs%T%SL_BATTERY_MONITOR_TX_ACTIVE%T%sl_battery_monitor_config.h"/>
+    <property object="PRS.CH0" propertyId="ABPeripheral.included" value="true"/>
+    <property object="PTI" propertyId="ABModule.selectedRequirement" value="pti%T%SL_RAIL_UTIL_PTI%T%sl_rail_util_pti_config.h"/>
+    <property object="PTI" propertyId="ABPeripheral.included" value="true"/>
+    <property object="TIMER0" propertyId="ABModule.selectedRequirement" value="timer%T%SL_SIMPLE_RGB_PWM_LED_RGB_LED0%T%sl_simple_rgb_pwm_led_rgb_led0_config.h"/>
+    <property object="TIMER0" propertyId="ABPeripheral.included" value="true"/>
+    <property object="TIMER0" propertyId="channel.0.name" value="RED"/>
+    <property object="TIMER0" propertyId="channel.1.name" value="GREEN"/>
+    <property object="TIMER0" propertyId="channel.2.name" value="BLUE"/>
+    <property object="USART0" propertyId="ABModule.selectedRequirement" value="usart%T%SL_IOSTREAM_USART_VCOM%T%sl_iostream_usart_vcom_config.h"/>
+    <property object="USART0" propertyId="ABPeripheral.included" value="true"/>
+    <property object="USART3" propertyId="ABModule.selectedRequirement" value="usart%T%SL_ICM20648_SPI%T%sl_icm20648_config.h"/>
+    <property object="USART3" propertyId="ABPeripheral.included" value="true"/>
   </mode>
   <modeTransition>
     <property object="RESET &#x2192; DefaultMode" propertyId="modeTransition.source" value="RESET"/>

--- a/TBS2Torch/TBS2Torch.slcp
+++ b/TBS2Torch/TBS2Torch.slcp
@@ -97,6 +97,7 @@ component:
 - {id: si70xx_driver}
 - {id: sensor_rht}
 - {id: imu_driver}
+- {from: raz1_custom_components, id: power_configuration_server}
 config_file:
 - {path: config/zcl/zcl_config.zap, directory: zcl}
 configuration:
@@ -119,4 +120,5 @@ ui_hints:
   highlight:
   - {path: '', focus: true}
   - {path: readme.html}
-
+sdk_extension:
+- {id: raz1_custom_components, version: 0.0.1}

--- a/TBS2Torch/app.c
+++ b/TBS2Torch/app.c
@@ -77,6 +77,7 @@ void emberAfMainInitCallback(void)
   sl_status_t status = handlerHallInit();
   sl_zigbee_app_debug_println("Hall Sensor init status: 0x%02x", status);
   handlerShakerInit();
+  emberSetPowerDescriptor(ZDO_POWER_DESCRIPTOR);
 }
 
 /** @brief Post Attribute Change

--- a/TBS2Torch/config/app-global.h
+++ b/TBS2Torch/config/app-global.h
@@ -17,4 +17,8 @@
 // Fade in transition time in 10th of sec
 #define FADEIN_TRANSITION_TIME 5*10
 
+#ifndef ZDO_POWER_DESCRIPTOR
+#define ZDO_POWER_DESCRIPTOR 0x0220
+#endif  // ZDO_POWER_DESCRIPTOR
+
 #endif /* CONFIG_APP_GLOBAL_H_ */

--- a/TBS2Torch/config/pin_config.h
+++ b/TBS2Torch/config/pin_config.h
@@ -114,6 +114,17 @@
 // [PCNT2]$
 
 // $[PRS.CH0]
+// PRS CH0 on PC6
+#ifndef PRS_CH0_PORT                            
+#define PRS_CH0_PORT                             gpioPortC
+#endif
+#ifndef PRS_CH0_PIN                             
+#define PRS_CH0_PIN                              6
+#endif
+#ifndef PRS_CH0_LOC                             
+#define PRS_CH0_LOC                              8
+#endif
+
 // [PRS.CH0]$
 
 // $[PRS.CH1]

--- a/TBS2Torch/config/power_configuration_server_config.h
+++ b/TBS2Torch/config/power_configuration_server_config.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * @file
+ * @brief Power Configuration Server Cluster
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Alexei Chetroi</b>
+ *******************************************************************************
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#ifndef SL_POWER_CONFIGURATION_SERVER_CONFIG_H
+#define SL_POWER_CONFIGURATION_SERVER_CONFIG_H
+
+#define SL_POWER_CONFIGURATION_BATTERY_TYPE_CUSTOM 0
+#define SL_POWER_CONFIGURATION_BATTERY_TYPE_CR2032 1
+#define SL_POWER_CONFIGURATION_BATTERY_TYPE_18650  2
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Power Configuration Server Cluster configuration
+
+// <o SL_POWER_CONFIGURATION_BATTERY_TYPE> Battery Type
+// <i> Default: CR2032
+// <i> Indicates the battery type in use.
+// <SL_POWER_CONFIGURATION_BATTERY_TYPE_CUSTOM=> CUSTOM
+// <SL_POWER_CONFIGURATION_BATTERY_TYPE_CR2023=> CR2032
+// <SL_POWER_CONFIGURATION_BATTERY_TYPE_18650=> 18650
+#define SL_POWER_CONFIGURATION_BATTERY_TYPE   SL_POWER_CONFIGURATION_BATTERY_TYPE_18650
+
+// </h>
+
+// <<< end of configuration section >>>
+#endif  // SL_POWER_CONFIGURATION_SERVER_CONFIG_H

--- a/TBS2Torch/config/sl_battery_monitor_config.h
+++ b/TBS2Torch/config/sl_battery_monitor_config.h
@@ -1,0 +1,261 @@
+/***************************************************************************//**
+ * @file
+ * @brief sl_battery_monitor Config
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#ifndef SL_BATTERY_MONITOR_CONFIG_H
+#define SL_BATTERY_MONITOR_CONFIG_H
+
+#include "em_adc.h"
+
+// <<< Use Configuration Wizard in Context Menu
+
+// <h> Battery Monitor settings
+
+// <o SL_BATTERY_MONITOR_TIMEOUT_MINUTES> Monitor Timeout (Minutes)
+// <1..1000:1>
+// <i> Default: 30
+// <i> The length of time between battery reads.
+#define SL_BATTERY_MONITOR_TIMEOUT_MINUTES 60
+
+// <o SL_BATTERY_MONITOR_SAMPLE_FIFO_SIZE> Sample Collection FIFO Size
+// <1..20:1>
+// <i> Default: 16
+// <i> The number of entries in the fifo used to collect ADC reads of the battery
+#define SL_BATTERY_MONITOR_SAMPLE_FIFO_SIZE 16
+
+// <o SL_BATTERY_MONITOR_ADC_POS_SEL> ADC Pos Select Input
+// <i> Default: AVDD
+// <adcPosSelAVDD=> AVDD
+// <adcPosSelAPORT0XCH0=> APORT0XCH0
+// <adcPosSelAPORT0XCH1=> APORT0XCH1
+// <adcPosSelAPORT0XCH2=> APORT0XCH2
+// <adcPosSelAPORT0XCH3=> APORT0XCH3
+// <adcPosSelAPORT0XCH4=> APORT0XCH4
+// <adcPosSelAPORT0XCH5=> APORT0XCH5
+// <adcPosSelAPORT0XCH6=> APORT0XCH6
+// <adcPosSelAPORT0XCH7=> APORT0XCH7
+// <adcPosSelAPORT0XCH8=> APORT0XCH8
+// <adcPosSelAPORT0XCH9=> APORT0XCH9
+// <adcPosSelAPORT0XCH10=> APORT0XCH10
+// <adcPosSelAPORT0XCH11=> APORT0XCH11
+// <adcPosSelAPORT0XCH12=> APORT0XCH12
+// <adcPosSelAPORT0XCH13=> APORT0XCH13
+// <adcPosSelAPORT0XCH14=> APORT0XCH14
+// <adcPosSelAPORT0XCH15=> APORT0XCH15
+// <adcPosSelAPORT0YCH0=> APORT0YCH0
+// <adcPosSelAPORT0YCH1=> APORT0YCH1
+// <adcPosSelAPORT0YCH2=> APORT0YCH2
+// <adcPosSelAPORT0YCH3=> APORT0YCH3
+// <adcPosSelAPORT0YCH4=> APORT0YCH4
+// <adcPosSelAPORT0YCH5=> APORT0YCH5
+// <adcPosSelAPORT0YCH6=> APORT0YCH6
+// <adcPosSelAPORT0YCH7=> APORT0YCH7
+// <adcPosSelAPORT0YCH8=> APORT0YCH8
+// <adcPosSelAPORT0YCH9=> APORT0YCH9
+// <adcPosSelAPORT0YCH10=> APORT0YCH10
+// <adcPosSelAPORT0YCH11=> APORT0YCH11
+// <adcPosSelAPORT0YCH12=> APORT0YCH12
+// <adcPosSelAPORT0YCH13=> APORT0YCH13
+// <adcPosSelAPORT0YCH14=> APORT0YCH14
+// <adcPosSelAPORT0YCH15=> APORT0YCH15
+// <adcPosSelAPORT1XCH0=> APORT1XCH0
+// <adcPosSelAPORT1YCH1=> APORT1YCH1
+// <adcPosSelAPORT1XCH2=> APORT1XCH2
+// <adcPosSelAPORT1YCH3=> APORT1YCH3
+// <adcPosSelAPORT1XCH4=> APORT1XCH4
+// <adcPosSelAPORT1YCH5=> APORT1YCH5
+// <adcPosSelAPORT1XCH6=> APORT1XCH6
+// <adcPosSelAPORT1YCH7=> APORT1YCH7
+// <adcPosSelAPORT1XCH8=> APORT1XCH8
+// <adcPosSelAPORT1YCH9=> APORT1YCH9
+// <adcPosSelAPORT1XCH10=> APORT1XCH10
+// <adcPosSelAPORT1YCH11=> APORT1YCH11
+// <adcPosSelAPORT1XCH12=> APORT1XCH12
+// <adcPosSelAPORT1YCH13=> APORT1YCH13
+// <adcPosSelAPORT1XCH14=> APORT1XCH14
+// <adcPosSelAPORT1YCH15=> APORT1YCH15
+// <adcPosSelAPORT1XCH16=> APORT1XCH16
+// <adcPosSelAPORT1YCH17=> APORT1YCH17
+// <adcPosSelAPORT1XCH18=> APORT1XCH18
+// <adcPosSelAPORT1YCH19=> APORT1YCH19
+// <adcPosSelAPORT1XCH20=> APORT1XCH20
+// <adcPosSelAPORT1YCH21=> APORT1YCH21
+// <adcPosSelAPORT1XCH22=> APORT1XCH22
+// <adcPosSelAPORT1YCH23=> APORT1YCH23
+// <adcPosSelAPORT1XCH24=> APORT1XCH24
+// <adcPosSelAPORT1YCH25=> APORT1YCH25
+// <adcPosSelAPORT1XCH26=> APORT1XCH26
+// <adcPosSelAPORT1YCH27=> APORT1YCH27
+// <adcPosSelAPORT1XCH28=> APORT1XCH28
+// <adcPosSelAPORT1YCH29=> APORT1YCH29
+// <adcPosSelAPORT1XCH30=> APORT1XCH30
+// <adcPosSelAPORT1YCH31=> APORT1YCH31
+// <adcPosSelAPORT2YCH0=> APORT2YCH0
+// <adcPosSelAPORT2XCH1=> APORT2XCH1
+// <adcPosSelAPORT2YCH2=> APORT2YCH2
+// <adcPosSelAPORT2XCH3=> APORT2XCH3
+// <adcPosSelAPORT2YCH4=> APORT2YCH4
+// <adcPosSelAPORT2XCH5=> APORT2XCH5
+// <adcPosSelAPORT2YCH6=> APORT2YCH6
+// <adcPosSelAPORT2XCH7=> APORT2XCH7
+// <adcPosSelAPORT2YCH8=> APORT2YCH8
+// <adcPosSelAPORT2XCH9=> APORT2XCH9
+// <adcPosSelAPORT2YCH10=> APORT2YCH10
+// <adcPosSelAPORT2XCH11=> APORT2XCH11
+// <adcPosSelAPORT2YCH12=> APORT2YCH12
+// <adcPosSelAPORT2XCH13=> APORT2XCH13
+// <adcPosSelAPORT2YCH14=> APORT2YCH14
+// <adcPosSelAPORT2XCH15=> APORT2XCH15
+// <adcPosSelAPORT2YCH16=> APORT2YCH16
+// <adcPosSelAPORT2XCH17=> APORT2XCH17
+// <adcPosSelAPORT2YCH18=> APORT2YCH18
+// <adcPosSelAPORT2XCH19=> APORT2XCH19
+// <adcPosSelAPORT2YCH20=> APORT2YCH20
+// <adcPosSelAPORT2XCH21=> APORT2XCH21
+// <adcPosSelAPORT2YCH22=> APORT2YCH22
+// <adcPosSelAPORT2XCH23=> APORT2XCH23
+// <adcPosSelAPORT2YCH24=> APORT2YCH24
+// <adcPosSelAPORT2XCH25=> APORT2XCH25
+// <adcPosSelAPORT2YCH26=> APORT2YCH26
+// <adcPosSelAPORT2XCH27=> APORT2XCH27
+// <adcPosSelAPORT2YCH28=> APORT2YCH28
+// <adcPosSelAPORT2XCH29=> APORT2XCH29
+// <adcPosSelAPORT2YCH30=> APORT2YCH30
+// <adcPosSelAPORT2XCH31=> APORT2XCH31
+// <adcPosSelAPORT3XCH0=> APORT3XCH0
+// <adcPosSelAPORT3YCH1=> APORT3YCH1
+// <adcPosSelAPORT3XCH2=> APORT3XCH2
+// <adcPosSelAPORT3YCH3=> APORT3YCH3
+// <adcPosSelAPORT3XCH4=> APORT3XCH4
+// <adcPosSelAPORT3YCH5=> APORT3YCH5
+// <adcPosSelAPORT3XCH6=> APORT3XCH6
+// <adcPosSelAPORT3YCH7=> APORT3YCH7
+// <adcPosSelAPORT3XCH8=> APORT3XCH8
+// <adcPosSelAPORT3YCH9=> APORT3YCH9
+// <adcPosSelAPORT3XCH10=> APORT3XCH10
+// <adcPosSelAPORT3YCH11=> APORT3YCH11
+// <adcPosSelAPORT3XCH12=> APORT3XCH12
+// <adcPosSelAPORT3YCH13=> APORT3YCH13
+// <adcPosSelAPORT3XCH14=> APORT3XCH14
+// <adcPosSelAPORT3YCH15=> APORT3YCH15
+// <adcPosSelAPORT3XCH16=> APORT3XCH16
+// <adcPosSelAPORT3YCH17=> APORT3YCH17
+// <adcPosSelAPORT3XCH18=> APORT3XCH18
+// <adcPosSelAPORT3YCH19=> APORT3YCH19
+// <adcPosSelAPORT3XCH20=> APORT3XCH20
+// <adcPosSelAPORT3YCH21=> APORT3YCH21
+// <adcPosSelAPORT3XCH22=> APORT3XCH22
+// <adcPosSelAPORT3YCH23=> APORT3YCH23
+// <adcPosSelAPORT3XCH24=> APORT3XCH24
+// <adcPosSelAPORT3YCH25=> APORT3YCH25
+// <adcPosSelAPORT3XCH26=> APORT3XCH26
+// <adcPosSelAPORT3YCH27=> APORT3YCH27
+// <adcPosSelAPORT3XCH28=> APORT3XCH28
+// <adcPosSelAPORT3YCH29=> APORT3YCH29
+// <adcPosSelAPORT3XCH30=> APORT3XCH30
+// <adcPosSelAPORT3YCH31=> APORT3YCH31
+// <adcPosSelAPORT4YCH0=> APORT4YCH0
+// <adcPosSelAPORT4XCH1=> APORT4XCH1
+// <adcPosSelAPORT4YCH2=> APORT4YCH2
+// <adcPosSelAPORT4XCH3=> APORT4XCH3
+// <adcPosSelAPORT4YCH4=> APORT4YCH4
+// <adcPosSelAPORT4XCH5=> APORT4XCH5
+// <adcPosSelAPORT4YCH6=> APORT4YCH6
+// <adcPosSelAPORT4XCH7=> APORT4XCH7
+// <adcPosSelAPORT4YCH8=> APORT4YCH8
+// <adcPosSelAPORT4XCH9=> APORT4XCH9
+// <adcPosSelAPORT4YCH10=> APORT4YCH10
+// <adcPosSelAPORT4XCH11=> APORT4XCH11
+// <adcPosSelAPORT4YCH12=> APORT4YCH12
+// <adcPosSelAPORT4XCH13=> APORT4XCH13
+// <adcPosSelAPORT4YCH14=> APORT4YCH14
+// <adcPosSelAPORT4XCH15=> APORT4XCH15
+// <adcPosSelAPORT4YCH16=> APORT4YCH16
+// <adcPosSelAPORT4XCH17=> APORT4XCH17
+// <adcPosSelAPORT4YCH18=> APORT4YCH18
+// <adcPosSelAPORT4XCH19=> APORT4XCH19
+// <adcPosSelAPORT4YCH20=> APORT4YCH20
+// <adcPosSelAPORT4XCH21=> APORT4XCH21
+// <adcPosSelAPORT4YCH22=> APORT4YCH22
+// <adcPosSelAPORT4XCH23=> APORT4XCH23
+// <adcPosSelAPORT4YCH24=> APORT4YCH24
+// <adcPosSelAPORT4XCH25=> APORT4XCH25
+// <adcPosSelAPORT4YCH26=> APORT4YCH26
+// <adcPosSelAPORT4XCH27=> APORT4XCH27
+// <adcPosSelAPORT4YCH28=> APORT4YCH28
+// <adcPosSelAPORT4XCH29=> APORT4XCH29
+// <adcPosSelAPORT4YCH30=> APORT4YCH30
+// <adcPosSelAPORT4XCH31=> APORT4XCH31
+// <adcPosSelAVDD=> AVDD
+// <adcPosSelBUVDD=> BUVDD
+// <adcPosSelDVDD=> DVDD
+// <adcPosSelPAVDD=> PAVDD
+// <adcPosSelDECOUPLE=> DECOUPLE
+// <adcPosSelIOVDD=> IOVDD
+// <adcPosSelIOVDD1=> IOVDD1
+// <adcPosSelVSP=> VSP
+// <adcPosSelOPA2=> OPA2
+// <adcPosSelTEMP=> TEMP
+// <adcPosSelDAC0OUT0=> DAC0OUT0
+// <adcPosSelR5VOUT=> R5VOUT
+// <adcPosSelSP1=> SP1
+// <adcPosSelSP2=> SP2
+// <adcPosSelDAC0OUT1=> DAC0OUT1
+// <adcPosSelSUBLSB=> SUBLSB
+// <adcPosSelOPA3=> OPA3
+// <adcPosSelDEFAULT=> DEFAULT
+// <adcPosSelVSS=> VSS
+#define SL_BATTERY_MONITOR_ADC_POS_SEL          adcPosSelAPORT3XCH14
+
+// <e SL_BATTERY_MONITOR_R_DIVIDER_ENABLED> Battery Voltage is using R1/R2 resistive divider
+#define SL_BATTERY_MONITOR_R_DIVIDER_ENABLED    1
+
+// <o SL_BATTERY_MONITOR_R_DIVIDER_R1> R1 Resistive divider Input Voltage leg
+#define SL_BATTERY_MONITOR_R_DIVIDER_R1         1800
+
+// <o SL_BATTERY_MONITOR_R_DIVIDER_R2> R2 Resistive divider Ground leg
+#define SL_BATTERY_MONITOR_R_DIVIDER_R2         2700
+// </e>
+
+// </h> end Battery Monitor config
+// <<< end of configuration section >>>
+
+#define SL_BATTERY_MONITOR_R_DIVIDER_R1_R2 (SL_BATTERY_MONITOR_R_DIVIDER_R1 \
+                                            + SL_BATTERY_MONITOR_R_DIVIDER_R2)
+#define SL_BATTERY_MONITOR_R_DIVIDER_COEF  (SL_BATTERY_MONITOR_R_DIVIDER_R1_R2 \
+                                            / SL_BATTERY_MONITOR_R_DIVIDER_R2)
+
+// <<< sl:start pin_tool >>>
+// <prs gpio=true > SL_BATTERY_MONITOR_TX_ACTIVE
+// $[PRS_SL_BATTERY_MONITOR_TX_ACTIVE]
+#ifndef SL_BATTERY_MONITOR_TX_ACTIVE_CHANNEL    
+#define SL_BATTERY_MONITOR_TX_ACTIVE_CHANNEL     0
+#endif
+
+// PRS CH0 on PC6
+#ifndef SL_BATTERY_MONITOR_TX_ACTIVE_PORT       
+#define SL_BATTERY_MONITOR_TX_ACTIVE_PORT        gpioPortC
+#endif
+#ifndef SL_BATTERY_MONITOR_TX_ACTIVE_PIN        
+#define SL_BATTERY_MONITOR_TX_ACTIVE_PIN         6
+#endif
+#ifndef SL_BATTERY_MONITOR_TX_ACTIVE_LOC        
+#define SL_BATTERY_MONITOR_TX_ACTIVE_LOC         8
+#endif
+// [PRS_SL_BATTERY_MONITOR_TX_ACTIVE]$
+// <<< sl:end pin_tool >>>
+
+#endif // SL_BATTERY_MONITOR_CONFIG_H

--- a/TBS2Torch/config/sl_battery_monitor_config.h
+++ b/TBS2Torch/config/sl_battery_monitor_config.h
@@ -235,8 +235,8 @@
 
 #define SL_BATTERY_MONITOR_R_DIVIDER_R1_R2 (SL_BATTERY_MONITOR_R_DIVIDER_R1 \
                                             + SL_BATTERY_MONITOR_R_DIVIDER_R2)
-#define SL_BATTERY_MONITOR_R_DIVIDER_COEF  (SL_BATTERY_MONITOR_R_DIVIDER_R1_R2 \
-                                            / SL_BATTERY_MONITOR_R_DIVIDER_R2)
+#define SL_BATTERY_MONITOR_R_DIVIDER_COEF  SL_BATTERY_MONITOR_R_DIVIDER_R1_R2 \
+                                           / SL_BATTERY_MONITOR_R_DIVIDER_R2
 
 // <<< sl:start pin_tool >>>
 // <prs gpio=true > SL_BATTERY_MONITOR_TX_ACTIVE

--- a/TBS2Torch/config/zcl/zcl_config.zap
+++ b/TBS2Torch/config/zcl/zcl_config.zap
@@ -205,7 +205,7 @@
               "storageOption": "RAM",
               "singleton": 1,
               "bounded": 0,
-              "defaultValue": "0x00",
+              "defaultValue": "0x03",
               "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/TBS2Torch/config/zcl/zcl_config.zap
+++ b/TBS2Torch/config/zcl/zcl_config.zap
@@ -310,6 +310,106 @@
           ]
         },
         {
+          "name": "Power Configuration",
+          "code": 1,
+          "mfgCode": null,
+          "define": "POWER_CONFIG_CLUSTER",
+          "side": "client",
+          "enabled": 0,
+          "attributes": [
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "2",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Power Configuration",
+          "code": 1,
+          "mfgCode": null,
+          "define": "POWER_CONFIG_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "attributes": [
+            {
+              "name": "battery voltage",
+              "code": 32,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int8u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 14400,
+              "reportableChange": 2
+            },
+            {
+              "name": "battery percentage remaining",
+              "code": 33,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int8u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0x00",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 14400,
+              "reportableChange": 2
+            },
+            {
+              "name": "battery alarm state",
+              "code": 62,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "0x00000000",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "cluster revision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 1,
+              "bounded": 0,
+              "defaultValue": "2",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
           "name": "Identify",
           "code": 3,
           "mfgCode": null,

--- a/TBS2Torch/handlers/network.c
+++ b/TBS2Torch/handlers/network.c
@@ -14,6 +14,7 @@
 #include "find-and-bind-target.h"
 
 #include "network.h"
+#include "app-global.h"
 
 #if defined(SL_CATALOG_LED0_PRESENT)
 #include "led-blink.h"
@@ -87,6 +88,7 @@ void emberAfStackStatusCallback(EmberStatus status)
         networkHandlerAttemptToJoin(false);
     }
   } else if (status == EMBER_NETWORK_UP) {
+    emberSetPowerDescriptor(ZDO_POWER_DESCRIPTOR);
     networkState.joinAttempt = 0;
     handlerLedBlinkCountedBlink(LED_BLINK_NETWORK_UP_COUNT, LED_BLINK_SHORT_MS, COMMISSIONING_STATUS_LED);
     // delay finding & binding if network fluctuates


### PR DESCRIPTION
Add support for battery monitoring. By default is assuming to use a 18650 LiIon Cell and a 18K/27K Voltage divider connected to PA6 -- Expansion Header A pin `#7`