### PR TITLE
Refactor OTA versioning

### DIFF
--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -85,9 +85,9 @@ env:
   IS_NEW_PROJECT: ${{ inputs.export_project_name != '' && 'yes' || 'no' }}
   IS_BTL: ${{ startsWith(inputs.project_name, 'bootloader') && 'yes' || '' }}
   branch_to_ota: >-
-    ${{ github.ref_name == 'main' 
+    ${{ ( github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') )
         && '0'
-        || (startsWith(github.ref_name, 'rc')
+        || ( (startsWith(github.ref_name, 'rc') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')))
             && '5'
             || ( github.ref_name == 'dev'
                  && '9'

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -85,7 +85,7 @@ env:
   IS_NEW_PROJECT: ${{ inputs.export_project_name != '' && 'yes' || 'no' }}
   IS_BTL: ${{ startsWith(inputs.project_name, 'bootloader') && 'yes' || '' }}
   branch_to_ota: >-
-    ${{ ( github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') )
+    ${{ ( github.ref_name == 'main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')) )
         && '0'
         || ( (startsWith(github.ref_name, 'rc') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')))
             && '5'

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -86,12 +86,12 @@ env:
   IS_BTL: ${{ startsWith(inputs.project_name, 'bootloader') && 'yes' || '' }}
   branch_to_ota: >-
     ${{ ( github.ref_name == 'main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')) )
-        && '0'
+        && '9'
         || ( (startsWith(github.ref_name, 'rc') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')))
-            && '5'
+            && '7'
             || ( github.ref_name == 'dev'
-                 && '9'
-                 || '8')
+                 && '5'
+                 || '4')
         )
     }}
   branch_to_build_type: >-


### PR DESCRIPTION
Refactor how the OTA versioning is calculated, affected by the TAG names

List of OTA version priorities in descending order:
- Releases (or main branch) have the highest priority
- Release Candidates
- Dev branch
- Any other branch

This means, a new Release Candidate should be release next day after the
previous main release.